### PR TITLE
feat: [cublas] add multiple streams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,106 @@
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+.vscode/*
+# !.vscode/settings.json
+# !.vscode/tasks.json
+# !.vscode/launch.json
+# !.vscode/extensions.json
+# !.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+# build directory 
+build/
+
+# Others
+test_dgemm.x
+frida/
+

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ FFLAGS = -O2 -mp -g -mcmodel=large #$(MEMMODEL)
 
 BLAS_SRCS = $(wildcard blas/$(GPUARCH)/*.c)
 UTIL_SRCS = $(wildcard utils/*.c)
-COMMON_SRCS = init.c nvidia.c $(UTIL_SRCS) $(BLAS_SRCS)
+COMMON_SRCS = init.c nvidia.c scilib_pthread_wrap.c $(UTIL_SRCS) $(BLAS_SRCS)
 #COMMON_SRCS = init.c nvidia.c utils.c blas/$(GPUARCH)/sgemm.c blas/$(GPUARCH)/dgemm.c blas/$(GPUARCH)/cgemm.c blas/$(GPUARCH)/zgemm.c 
 
 SRCS1 = main-dbi.c

--- a/blas/NVIDIA/cgemm.c
+++ b/blas/NVIDIA/cgemm.c
@@ -56,6 +56,7 @@ void _CGEMM( const char* transa, const char* transb, const int* m, const int* n,
          return;
     }
 
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
     DEBUG2(fprintf(stderr, "gpu: cgemm args: transa=%c, transb=%c, m=%d, n=%d, k=%d, alpha=(%.1e, %.1e), lda=%d, ldb=%d, beta=(%.1e, %.1e),ldc=%d\n",
        *transa, *transb, *m, *n, *k, crealf(*(float complex*)alpha), cimagf(*(float complex*)alpha), 
        *lda, *ldb, crealf(*(float complex*)beta), cimagf(*(float complex*)beta), *ldc));
@@ -91,26 +92,27 @@ void _CGEMM( const char* transa, const char* transb, const int* m, const int* n,
 if (scilib_offload_mode==1) {
     cuFloatComplex *d_A, *d_B, *d_C;
 
-    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(_CUBLASCGEMM(scilib_cublas_handle, transA, transB, *m, *n, *k, alpha, d_A, *lda, d_B, *ldb, beta, d_C, *ldc));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG1(t1 += scilib_second());
-    CUDA_CHECK(cudaMemcpyAsync(C, d_C, sizeC, cudaMemcpyDeviceToHost, scilib_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(C, d_C, sizeC, cudaMemcpyDeviceToHost, current_cuda_stream));
 
-    CUDA_CHECK(cudaDeviceSynchronize());
-    CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_B, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_C, scilib_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_B, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_C, current_cuda_stream));
 
 } 
 else {
@@ -127,8 +129,9 @@ else {
     }
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(_CUBLASCGEMM(scilib_cublas_handle, transA, transB, *m, *n, *k, alpha, A, *lda, B, *ldb, beta, C, *ldc));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG1(t1 += scilib_second());
 }
 

--- a/blas/NVIDIA/chemm.c
+++ b/blas/NVIDIA/chemm.c
@@ -52,6 +52,7 @@ void _CHEMM(const char *side, const char *uplo, const int *m, const int *n, cons
 
          return;
     }
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
          DEBUG2(fprintf(stderr,"gpu: chemm args: side=%c, uplo=%c, m=%d, n=%d, alpha=(%.1e, %.1e), lda=%d, ldb=%d, beta=(%.1e, %.1e), ldc=%d\n",
            *side, *uplo, *m, *n, crealf(*(float complex*)alpha), cimagf(*(float complex*)alpha),
            *lda, *ldb,crealf(*(float complex*)beta),cimagf(*(float complex*)beta) , *ldc));
@@ -62,26 +63,27 @@ void _CHEMM(const char *side, const char *uplo, const int *m, const int *n, cons
 if(scilib_offload_mode == 1){
     cuFloatComplex *d_A, *d_B, *d_C;
 
-    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, scilib_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, current_cuda_stream));
 //    if( beta_abs > 1.0e-8 )  bug if gemm on a submatrix
-    CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasChemm(scilib_cublas_handle, gpu_side, gpu_uplo, *m, *n, alpha, A, *lda, B, *ldb, beta, C, *ldc));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG1(t1 += scilib_second());
     CUDA_CHECK(cudaMemcpy(C, d_C, sizeC, cudaMemcpyDeviceToHost));
 
-    CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_B, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_C, scilib_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_B, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_C, current_cuda_stream));
 
 }
 else {
@@ -98,8 +100,9 @@ else {
     }
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasChemm(scilib_cublas_handle, gpu_side, gpu_uplo, *m, *n, alpha, A, *lda, B, *ldb, beta, C, *ldc));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG3(fprintf(stderr,"c,NUMA location of A,B,C: %d %d %d\n", inumaA, inumaB, inumaC));
     DEBUG1(t1 += scilib_second());
 }

--- a/blas/NVIDIA/cher2k.c
+++ b/blas/NVIDIA/cher2k.c
@@ -50,6 +50,7 @@ void _CHER2K(const char *uplo, const char *trans, const int *n, const int *k, co
         return;
     }
 
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
     DEBUG2(fprintf(stderr,"gpu: cher2k args: uplo=%c, trans=%c, n=%d, k=%d, alpha=(%.1e, %.1e), lda=%d, ldb=%d, beta=(%.1e, %.1e), ldc=%d\n",
       *uplo, *trans, *n, *k, crealf(*(float complex*)alpha), cimagf(*(float complex*)alpha),
       *lda, *ldb, crealf(*(float complex*)beta), cimagf(*(float complex*)beta), *ldc));
@@ -60,25 +61,26 @@ void _CHER2K(const char *uplo, const char *trans, const int *n, const int *k, co
     if(scilib_offload_mode == 1) {
         cuFloatComplex *d_A, *d_B, *d_C;
 
-        CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-        CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, scilib_cuda_stream));
-        CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, scilib_cuda_stream));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+        CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, current_cuda_stream));
+        CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, current_cuda_stream));
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-        CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
         DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
         CUBLAS_CHECK(cublasCher2k(scilib_cublas_handle, gpu_uplo, gpu_trans, *n, *k, alpha, d_A, *lda, d_B, *ldb, beta, d_C, *ldc));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
         DEBUG1(t1 += scilib_second());
         CUDA_CHECK(cudaMemcpy(C, d_C, sizeC, cudaMemcpyDeviceToHost));
 
-        CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-        CUDA_CHECK(cudaFreeAsync(d_B, scilib_cuda_stream));
-        CUDA_CHECK(cudaFreeAsync(d_C, scilib_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_B, current_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_C, current_cuda_stream));
     }
     else {
         int inumaA, inumaB, inumaC;
@@ -94,8 +96,9 @@ void _CHER2K(const char *uplo, const char *trans, const int *n, const int *k, co
         }
 
         DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
         CUBLAS_CHECK(cublasCher2k(scilib_cublas_handle, gpu_uplo, gpu_trans, *n, *k, alpha, A, *lda, B, *ldb, beta, C, *ldc));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
         DEBUG3(fprintf(stderr,"c,NUMA location of A,B,C: %d %d %d\n", inumaA, inumaB, inumaC));
         DEBUG1(t1 += scilib_second());
     }

--- a/blas/NVIDIA/cherk.c
+++ b/blas/NVIDIA/cherk.c
@@ -48,6 +48,7 @@ void _CHERK(const char *uplo, const char *trans, const int *n, const int *k, con
         return;
     }
 
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
     DEBUG2(fprintf(stderr,"gpu: cherk args: uplo=%c, trans=%c, n=%d, k=%d, alpha=(%.1e, %.1e), lda=%d, beta=(%.1e, %.1e), ldc=%d\n",
       *uplo, *trans, *n, *k, crealf(*(float complex*)alpha), cimagf(*(float complex*)alpha),
       *lda, crealf(*(float complex*)beta), cimagf(*(float complex*)beta), *ldc));
@@ -58,22 +59,23 @@ void _CHERK(const char *uplo, const char *trans, const int *n, const int *k, con
     if(scilib_offload_mode == 1) {
         cuFloatComplex *d_A, *d_C;
 
-        CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-        CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, scilib_cuda_stream));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+        CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, current_cuda_stream));
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-        CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
         DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
         CUBLAS_CHECK(cublasCherk(scilib_cublas_handle, gpu_uplo, gpu_trans, *n, *k, alpha, d_A, *lda, beta, d_C, *ldc));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
         DEBUG1(t1 += scilib_second());
         CUDA_CHECK(cudaMemcpy(C, d_C, sizeC, cudaMemcpyDeviceToHost));
 
-        CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-        CUDA_CHECK(cudaFreeAsync(d_C, scilib_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_C, current_cuda_stream));
     }
     else {
         int inumaA, inumaC;
@@ -87,8 +89,9 @@ void _CHERK(const char *uplo, const char *trans, const int *n, const int *k, con
         }
 
         DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
         CUBLAS_CHECK(cublasCherk(scilib_cublas_handle, gpu_uplo, gpu_trans, *n, *k, alpha, A, *lda, beta, C, *ldc));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
         DEBUG3(fprintf(stderr,"c,NUMA location of A,C: %d %d\n", inumaA, inumaC));
         DEBUG1(t1 += scilib_second());
     }

--- a/blas/NVIDIA/csymm.c
+++ b/blas/NVIDIA/csymm.c
@@ -52,6 +52,7 @@ void _CSYMM(const char *side, const char *uplo, const int *m, const int *n, cons
 
          return;
     }
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
          DEBUG2(fprintf(stderr,"gpu: csymm args: side=%c, uplo=%c, m=%d, n=%d, alpha=(%.1e, %.1e), lda=%d, ldb=%d, beta=(%.1e, %.1e), ldc=%d\n",
            *side, *uplo, *m, *n, crealf(*(float complex*)alpha), cimagf(*(float complex*)alpha),
            *lda, *ldb,crealf(*(float complex*)beta),cimagf(*(float complex*)beta) , *ldc));
@@ -62,26 +63,27 @@ void _CSYMM(const char *side, const char *uplo, const int *m, const int *n, cons
 if(scilib_offload_mode == 1){
     cuFloatComplex *d_A, *d_B, *d_C;
 
-    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, scilib_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, current_cuda_stream));
 //    if( beta_abs > 1.0e-8 )  bug if gemm on a submatrix
-    CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasCsymm(scilib_cublas_handle, gpu_side, gpu_uplo, *m, *n, alpha, A, *lda, B, *ldb, beta, C, *ldc));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG1(t1 += scilib_second());
     CUDA_CHECK(cudaMemcpy(C, d_C, sizeC, cudaMemcpyDeviceToHost));
 
-    CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_B, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_C, scilib_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_B, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_C, current_cuda_stream));
 
 }
 else {
@@ -98,8 +100,9 @@ else {
     }
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasCsymm(scilib_cublas_handle, gpu_side, gpu_uplo, *m, *n, alpha, A, *lda, B, *ldb, beta, C, *ldc));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG3(fprintf(stderr,"c,NUMA location of A,B,C: %d %d %d\n", inumaA, inumaB, inumaC));
     DEBUG1(t1 += scilib_second());
 }

--- a/blas/NVIDIA/csyr2k.c
+++ b/blas/NVIDIA/csyr2k.c
@@ -50,6 +50,7 @@ void _CSYR2K(const char *uplo, const char *trans, const int *n, const int *k, co
         return;
     }
 
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
     DEBUG2(fprintf(stderr,"gpu: csyr2k args: uplo=%c, trans=%c, n=%d, k=%d, alpha=(%.1e, %.1e), lda=%d, ldb=%d, beta=(%.1e, %.1e), ldc=%d\n",
       *uplo, *trans, *n, *k, crealf(*(float complex*)alpha), cimagf(*(float complex*)alpha),
       *lda, *ldb, crealf(*(float complex*)beta), cimagf(*(float complex*)beta), *ldc));
@@ -68,25 +69,26 @@ void _CSYR2K(const char *uplo, const char *trans, const int *n, const int *k, co
     if(scilib_offload_mode == 1) {
         cuFloatComplex *d_A, *d_B, *d_C;
 
-        CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-        CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, scilib_cuda_stream));
-        CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, scilib_cuda_stream));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+        CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, current_cuda_stream));
+        CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, current_cuda_stream));
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-        CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
         DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
         CUBLAS_CHECK(cublasCsyr2k(scilib_cublas_handle, gpu_uplo, gpu_trans, *n, *k, alpha, d_A, *lda, d_B, *ldb, beta, d_C, *ldc));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
         DEBUG1(t1 += scilib_second());
         CUDA_CHECK(cudaMemcpy(C, d_C, sizeC, cudaMemcpyDeviceToHost));
 
-        CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-        CUDA_CHECK(cudaFreeAsync(d_B, scilib_cuda_stream));
-        CUDA_CHECK(cudaFreeAsync(d_C, scilib_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_B, current_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_C, current_cuda_stream));
     }
     else {
         int inumaA, inumaB, inumaC;
@@ -102,8 +104,9 @@ void _CSYR2K(const char *uplo, const char *trans, const int *n, const int *k, co
         }
 
         DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
         CUBLAS_CHECK(cublasCsyr2k(scilib_cublas_handle, gpu_uplo, gpu_trans, *n, *k, alpha, A, *lda, B, *ldb, beta, C, *ldc));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
         DEBUG3(fprintf(stderr,"c,NUMA location of A,B,C: %d %d %d\n", inumaA, inumaB, inumaC));
         DEBUG1(t1 += scilib_second());
     }

--- a/blas/NVIDIA/csyrk.c
+++ b/blas/NVIDIA/csyrk.c
@@ -48,6 +48,7 @@ void _CSYRK(const char *uplo, const char *trans, const int *n, const int *k, con
         return;
     }
 
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
     DEBUG2(fprintf(stderr,"gpu: csyrk args: uplo=%c, trans=%c, n=%d, k=%d, alpha=(%.1e, %.1e), lda=%d, beta=(%.1e, %.1e), ldc=%d\n",
       *uplo, *trans, *n, *k, crealf(*(float complex*)alpha), cimagf(*(float complex*)alpha),
       *lda, crealf(*(float complex*)beta), cimagf(*(float complex*)beta), *ldc));
@@ -66,22 +67,23 @@ void _CSYRK(const char *uplo, const char *trans, const int *n, const int *k, con
     if(scilib_offload_mode == 1) {
         cuFloatComplex *d_A, *d_C;
 
-        CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-        CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, scilib_cuda_stream));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+        CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, current_cuda_stream));
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-        CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
         DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
         CUBLAS_CHECK(cublasCsyrk(scilib_cublas_handle, gpu_uplo, gpu_trans, *n, *k, alpha, d_A, *lda, beta, d_C, *ldc));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
         DEBUG1(t1 += scilib_second());
         CUDA_CHECK(cudaMemcpy(C, d_C, sizeC, cudaMemcpyDeviceToHost));
 
-        CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-        CUDA_CHECK(cudaFreeAsync(d_C, scilib_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_C, current_cuda_stream));
     }
     else {
         int inumaA, inumaC;
@@ -95,8 +97,9 @@ void _CSYRK(const char *uplo, const char *trans, const int *n, const int *k, con
         }
 
         DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
         CUBLAS_CHECK(cublasCsyrk(scilib_cublas_handle, gpu_uplo, gpu_trans, *n, *k, alpha, A, *lda, beta, C, *ldc));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
         DEBUG3(fprintf(stderr,"c,NUMA location of A,C: %d %d\n", inumaA, inumaC));
         DEBUG1(t1 += scilib_second());
     }

--- a/blas/NVIDIA/ctrmm.c
+++ b/blas/NVIDIA/ctrmm.c
@@ -48,6 +48,7 @@ void _CTRMM(const char *side, const char *uplo, const char *transa, const char *
 
          return;
     }
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
     DEBUG2(fprintf(stderr,"gpu: ctrmm args: side=%c, uplo=%c, transa=%c, diag=%c, m=%d, n=%d, alpha=(%.1e, %.1e), lda=%d, ldb=%d\n",
         *side, *uplo, *transa, *diag, *m, *n, crealf(*(float complex*)alpha), cimagf(*(float complex*)alpha), *lda, *ldb));
 
@@ -60,22 +61,23 @@ void _CTRMM(const char *side, const char *uplo, const char *transa, const char *
 if(scilib_offload_mode == 1){
     cuFloatComplex *d_A, *d_B;
 
-    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasCtrmm(scilib_cublas_handle, gpu_side, gpu_uplo, gpu_transa, gpu_diag, *m, *n, alpha, d_A, *lda, d_B, *ldb, d_B, *ldb));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG1(t1 += scilib_second());
     CUDA_CHECK(cudaMemcpy(B, d_B, sizeB, cudaMemcpyDeviceToHost));
 
-    CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_B, scilib_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_B, current_cuda_stream));
 
 }
 else {
@@ -90,8 +92,9 @@ else {
     }
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasCtrmm(scilib_cublas_handle, gpu_side, gpu_uplo, gpu_transa, gpu_diag, *m, *n, alpha, A, *lda, B, *ldb, B, *ldb));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG3(fprintf(stderr,"c,NUMA location of A,B: %d %d\n", inumaA, inumaB));
     DEBUG1(t1 += scilib_second());
 }

--- a/blas/NVIDIA/ctrsm.c
+++ b/blas/NVIDIA/ctrsm.c
@@ -48,6 +48,7 @@ void _CTRSM(const char *side, const char *uplo, const char *transa, const char *
 
          return;
     }
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
     DEBUG2(fprintf(stderr,"gpu: ctrsm args: side=%c, uplo=%c, transa=%c, diag=%c, m=%d, n=%d, alpha=(%.1e, %.1e), lda=%d, ldb=%d\n",
         *side, *uplo, *transa, *diag, *m, *n, crealf(*(float complex*)alpha), cimagf(*(float complex*)alpha), *lda, *ldb));
 
@@ -60,22 +61,23 @@ void _CTRSM(const char *side, const char *uplo, const char *transa, const char *
 if(scilib_offload_mode == 1){
     cuFloatComplex *d_A, *d_B;
 
-    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasCtrsm(scilib_cublas_handle, gpu_side, gpu_uplo, gpu_transa, gpu_diag, *m, *n, alpha, d_A, *lda, d_B, *ldb));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG1(t1 += scilib_second());
     CUDA_CHECK(cudaMemcpy(B, d_B, sizeB, cudaMemcpyDeviceToHost));
 
-    CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_B, scilib_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_B, current_cuda_stream));
 
 }
 else {
@@ -90,8 +92,9 @@ else {
     }
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasCtrsm(scilib_cublas_handle, gpu_side, gpu_uplo, gpu_transa, gpu_diag, *m, *n, alpha, A, *lda, B, *ldb));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG3(fprintf(stderr,"c,NUMA location of A,B: %d %d\n", inumaA, inumaB));
     DEBUG1(t1 += scilib_second());
 }

--- a/blas/NVIDIA/dgemm.c
+++ b/blas/NVIDIA/dgemm.c
@@ -48,6 +48,7 @@ void _DGEMM( const char* transa, const char* transb, const int* m, const int* n,
 
          return;
     }
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
     DEBUG2(fprintf(stderr,"gpu: dgemm args: transa=%c, transb=%c, m=%d, n=%d, k=%d, alpha=%.1e, lda=%d, ldb=%d, beta=%.1e, ldc=%d\n",
         *transa, *transb, *m, *n, *k, *alpha, *lda, *ldb, *beta, *ldc));
 
@@ -57,26 +58,27 @@ void _DGEMM( const char* transa, const char* transb, const int* m, const int* n,
 if(scilib_offload_mode == 1){
     double *d_A, *d_B, *d_C;
 
-    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, scilib_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, current_cuda_stream));
 //    if( beta_abs > 1.0e-8 )  bug if gemm on a submatrix
-    CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasDgemm(scilib_cublas_handle, transA, transB, *m, *n, *k, alpha, d_A, *lda, d_B, *ldb, beta, d_C, *ldc));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG1(t1 += scilib_second());
     CUDA_CHECK(cudaMemcpy(C, d_C, sizeC, cudaMemcpyDeviceToHost));
 
-    CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_B, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_C, scilib_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_B, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_C, current_cuda_stream));
 
 }
 else {
@@ -93,8 +95,9 @@ else {
     }
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasDgemm(scilib_cublas_handle, transA, transB, *m, *n, *k, alpha, A, *lda, B, *ldb, beta, C, *ldc));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
        DEBUG3(fprintf(stderr,"c,NUMA location of A,B,C: %d %d %d\n", inumaA, inumaB, inumaC));
     DEBUG1(t1 += scilib_second());
 }

--- a/blas/NVIDIA/dsymm.c
+++ b/blas/NVIDIA/dsymm.c
@@ -51,6 +51,7 @@ void _DSYMM(const char *side, const char *uplo, const int *m, const int *n, cons
 
          return;
     }
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
     DEBUG2(fprintf(stderr,"gpu: dsymm args: side=%c, uplo=%c, m=%d, n=%d, alpha=%.1e, lda=%d, ldb=%d, beta=%.1e, ldc=%d\n",
         *side, *uplo, *m, *n, *alpha, *lda, *ldb, *beta, *ldc));
 
@@ -60,26 +61,27 @@ void _DSYMM(const char *side, const char *uplo, const int *m, const int *n, cons
 if(scilib_offload_mode == 1){
     double *d_A, *d_B, *d_C;
 
-    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, scilib_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, current_cuda_stream));
 //    if( beta_abs > 1.0e-8 )  bug if gemm on a submatrix
-    CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasDsymm(scilib_cublas_handle, gpu_side, gpu_uplo, *m, *n, alpha, A, *lda, B, *ldb, beta, C, *ldc));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG1(t1 += scilib_second());
     CUDA_CHECK(cudaMemcpy(C, d_C, sizeC, cudaMemcpyDeviceToHost));
 
-    CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_B, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_C, scilib_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_B, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_C, current_cuda_stream));
 
 }
 else {
@@ -96,8 +98,9 @@ else {
     }
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasDsymm(scilib_cublas_handle, gpu_side, gpu_uplo, *m, *n, alpha, A, *lda, B, *ldb, beta, C, *ldc));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG3(fprintf(stderr,"c,NUMA location of A,B,C: %d %d %d\n", inumaA, inumaB, inumaC));
     DEBUG1(t1 += scilib_second());
 }

--- a/blas/NVIDIA/dsyr2k.c
+++ b/blas/NVIDIA/dsyr2k.c
@@ -50,6 +50,7 @@ void _DSYR2K(const char *uplo, const char *trans, const int *n, const int *k, co
         return;
     }
 
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
     DEBUG2(fprintf(stderr,"gpu: dsyr2k args: uplo=%c, trans=%c, n=%d, k=%d, alpha=%.1e, \
       lda=%d, ldb=%d, beta=%.1e, ldc=%d\n",
       *uplo, *trans, *n, *k, *alpha, *lda, *ldb, *beta, *ldc));
@@ -67,25 +68,26 @@ void _DSYR2K(const char *uplo, const char *trans, const int *n, const int *k, co
     if(scilib_offload_mode == 1) {
         double *d_A, *d_B, *d_C;
 
-        CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-        CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, scilib_cuda_stream));
-        CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, scilib_cuda_stream));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+        CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, current_cuda_stream));
+        CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, current_cuda_stream));
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-        CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
         DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
         CUBLAS_CHECK(cublasDsyr2k(scilib_cublas_handle, gpu_uplo, gpu_trans, *n, *k, alpha, d_A, *lda, d_B, *ldb, beta, d_C, *ldc));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
         DEBUG1(t1 += scilib_second());
         CUDA_CHECK(cudaMemcpy(C, d_C, sizeC, cudaMemcpyDeviceToHost));
 
-        CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-        CUDA_CHECK(cudaFreeAsync(d_B, scilib_cuda_stream));
-        CUDA_CHECK(cudaFreeAsync(d_C, scilib_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_B, current_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_C, current_cuda_stream));
     }
     else {
         int inumaA, inumaB, inumaC;
@@ -101,8 +103,9 @@ void _DSYR2K(const char *uplo, const char *trans, const int *n, const int *k, co
         }
 
         DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
         CUBLAS_CHECK(cublasDsyr2k(scilib_cublas_handle, gpu_uplo, gpu_trans, *n, *k, alpha, A, *lda, B, *ldb, beta, C, *ldc));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
         DEBUG3(fprintf(stderr,"c,NUMA location of A,B,C: %d %d %d\n", inumaA, inumaB, inumaC));
         DEBUG1(t1 += scilib_second());
     }

--- a/blas/NVIDIA/dtrmm.c
+++ b/blas/NVIDIA/dtrmm.c
@@ -48,6 +48,7 @@ void _DTRMM(const char *side, const char *uplo, const char *transa, const char *
 
          return;
     }
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
     DEBUG2(fprintf(stderr,"gpu: dtrmm args: side=%c, uplo=%c, transa=%c, diag=%c, m=%d, n=%d, alpha=%.1e, lda=%d, ldb=%d\n",
         *side, *uplo, *transa, *diag, *m, *n, *alpha, *lda, *ldb));
 
@@ -60,22 +61,23 @@ void _DTRMM(const char *side, const char *uplo, const char *transa, const char *
 if(scilib_offload_mode == 1){
     double *d_A, *d_B;
 
-    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasDtrmm(scilib_cublas_handle, gpu_side, gpu_uplo, gpu_transa, gpu_diag, *m, *n, alpha, d_A, *lda, d_B, *ldb, d_B, *ldb));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG1(t1 += scilib_second());
     CUDA_CHECK(cudaMemcpy(B, d_B, sizeB, cudaMemcpyDeviceToHost));
 
-    CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_B, scilib_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_B, current_cuda_stream));
 
 }
 else {
@@ -90,8 +92,9 @@ else {
     }
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasDtrmm(scilib_cublas_handle, gpu_side, gpu_uplo, gpu_transa, gpu_diag, *m, *n, alpha, A, *lda, B, *ldb, B, *ldb));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG3(fprintf(stderr,"c,NUMA location of A,B: %d %d\n", inumaA, inumaB));
     DEBUG1(t1 += scilib_second());
 }

--- a/blas/NVIDIA/myblas.h
+++ b/blas/NVIDIA/myblas.h
@@ -13,6 +13,7 @@
 #include "global.h"
 #include "utils.h"
 #include "init.h"
+#include "scilib_pthread_wrap.h"
 
 
 

--- a/blas/NVIDIA/sgemm.c
+++ b/blas/NVIDIA/sgemm.c
@@ -47,6 +47,7 @@ void _SGEMM( const char* transa, const char* transb, const int* m, const int* n,
 
          return;
     }
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
     DEBUG2(fprintf(stderr,"gpu: sgemm args: transa=%c, transb=%c, m=%d, n=%d, k=%d, alpha=%.1f, lda=%d, ldb=%d, beta=%.1f, ldc=%d\n",
         *transa, *transb, *m, *n, *k, *alpha, *lda, *ldb, *beta, *ldc));
 
@@ -56,26 +57,27 @@ void _SGEMM( const char* transa, const char* transb, const int* m, const int* n,
 if(scilib_offload_mode == 1){
     float *d_A, *d_B, *d_C;
 
-    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, scilib_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, current_cuda_stream));
 //    if( beta_abs > 1.0e-8 )  bug if gemm on a submatrix
-    CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasSgemm(scilib_cublas_handle, transA, transB, *m, *n, *k, alpha, d_A, *lda, d_B, *ldb, beta, d_C, *ldc));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG1(t1 += scilib_second());
     CUDA_CHECK(cudaMemcpy(C, d_C, sizeC, cudaMemcpyDeviceToHost));
 
-    CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_B, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_C, scilib_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_B, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_C, current_cuda_stream));
 
 }
 else {
@@ -92,8 +94,9 @@ else {
     }
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasSgemm(scilib_cublas_handle, transA, transB, *m, *n, *k, alpha, A, *lda, B, *ldb, beta, C, *ldc));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
        DEBUG3(fprintf(stderr,"c,NUMA location of A,B,C: %d %d %d\n", inumaA, inumaB, inumaC));
     DEBUG1(t1 += scilib_second());
 }

--- a/blas/NVIDIA/ssyr2k.c
+++ b/blas/NVIDIA/ssyr2k.c
@@ -50,6 +50,7 @@ void _SSYR2K(const char *uplo, const char *trans, const int *n, const int *k, co
         return;
     }
 
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
     DEBUG2(fprintf(stderr,"gpu: ssyr2k args: uplo=%c, trans=%c, n=%d, k=%d, alpha=%.1e, \
       lda=%d, ldb=%d, beta=%.1e, ldc=%d\n",
       *uplo, *trans, *n, *k, *alpha, *lda, *ldb, *beta, *ldc));
@@ -67,25 +68,26 @@ void _SSYR2K(const char *uplo, const char *trans, const int *n, const int *k, co
     if(scilib_offload_mode == 1) {
         float *d_A, *d_B, *d_C;
 
-        CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-        CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, scilib_cuda_stream));
-        CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, scilib_cuda_stream));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+        CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, current_cuda_stream));
+        CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, current_cuda_stream));
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-        CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
         DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
         CUBLAS_CHECK(cublasSsyr2k(scilib_cublas_handle, gpu_uplo, gpu_trans, *n, *k, alpha, d_A, *lda, d_B, *ldb, beta, d_C, *ldc));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
         DEBUG1(t1 += scilib_second());
         CUDA_CHECK(cudaMemcpy(C, d_C, sizeC, cudaMemcpyDeviceToHost));
 
-        CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-        CUDA_CHECK(cudaFreeAsync(d_B, scilib_cuda_stream));
-        CUDA_CHECK(cudaFreeAsync(d_C, scilib_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_B, current_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_C, current_cuda_stream));
     }
     else {
         int inumaA, inumaB, inumaC;
@@ -101,8 +103,9 @@ void _SSYR2K(const char *uplo, const char *trans, const int *n, const int *k, co
         }
 
         DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
         CUBLAS_CHECK(cublasSsyr2k(scilib_cublas_handle, gpu_uplo, gpu_trans, *n, *k, alpha, A, *lda, B, *ldb, beta, C, *ldc));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
         DEBUG3(fprintf(stderr,"c,NUMA location of A,B,C: %d %d %d\n", inumaA, inumaB, inumaC));
         DEBUG1(t1 += scilib_second());
     }

--- a/blas/NVIDIA/ssyrk.c
+++ b/blas/NVIDIA/ssyrk.c
@@ -47,6 +47,7 @@ void _SSYRK(const char *uplo, const char *trans, const int *n, const int *k, con
         return;
     }
 
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
     DEBUG2(fprintf(stderr,"gpu: ssyrk args: uplo=%c, trans=%c, n=%d, k=%d, alpha=%.1e, lda=%d, beta=%.1e, ldc=%d\n",
         *uplo, *trans, *n, *k, *alpha, *lda, *beta, *ldc));
 
@@ -64,22 +65,23 @@ void _SSYRK(const char *uplo, const char *trans, const int *n, const int *k, con
     if(scilib_offload_mode == 1) {
         float *d_A, *d_C;
 
-        CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-        CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, scilib_cuda_stream));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+        CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, current_cuda_stream));
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-        CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
         DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
         CUBLAS_CHECK(cublasSsyrk(scilib_cublas_handle, gpu_uplo, gpu_trans, *n, *k, alpha, d_A, *lda, beta, d_C, *ldc));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
         DEBUG1(t1 += scilib_second());
         CUDA_CHECK(cudaMemcpy(C, d_C, sizeC, cudaMemcpyDeviceToHost));
 
-        CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-        CUDA_CHECK(cudaFreeAsync(d_C, scilib_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_C, current_cuda_stream));
     }
     else {
         int inumaA, inumaC;
@@ -93,8 +95,9 @@ void _SSYRK(const char *uplo, const char *trans, const int *n, const int *k, con
         }
 
         DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
         CUBLAS_CHECK(cublasSsyrk(scilib_cublas_handle, gpu_uplo, gpu_trans, *n, *k, alpha, A, *lda, beta, C, *ldc));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
         DEBUG3(fprintf(stderr,"c,NUMA location of A,C: %d %d\n", inumaA, inumaC));
         DEBUG1(t1 += scilib_second());
     }

--- a/blas/NVIDIA/strmm.c
+++ b/blas/NVIDIA/strmm.c
@@ -48,6 +48,7 @@ void _STRMM(const char *side, const char *uplo, const char *transa, const char *
 
          return;
     }
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
     DEBUG2(fprintf(stderr,"gpu: strmm args: side=%c, uplo=%c, transa=%c, diag=%c, m=%d, n=%d, alpha=%.1e, lda=%d, ldb=%d\n",
         *side, *uplo, *transa, *diag, *m, *n, *alpha, *lda, *ldb));
 
@@ -60,22 +61,23 @@ void _STRMM(const char *side, const char *uplo, const char *transa, const char *
 if(scilib_offload_mode == 1){
     float *d_A, *d_B;
 
-    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasStrmm(scilib_cublas_handle, gpu_side, gpu_uplo, gpu_transa, gpu_diag, *m, *n, alpha, d_A, *lda, d_B, *ldb, d_B, *ldb));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG1(t1 += scilib_second());
     CUDA_CHECK(cudaMemcpy(B, d_B, sizeB, cudaMemcpyDeviceToHost));
 
-    CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_B, scilib_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_B, current_cuda_stream));
 
 }
 else {
@@ -90,8 +92,9 @@ else {
     }
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasStrmm(scilib_cublas_handle, gpu_side, gpu_uplo, gpu_transa, gpu_diag, *m, *n, alpha, A, *lda, B, *ldb, B, *ldb));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG3(fprintf(stderr,"c,NUMA location of A,B: %d %d\n", inumaA, inumaB));
     DEBUG1(t1 += scilib_second());
 }

--- a/blas/NVIDIA/strsm.c
+++ b/blas/NVIDIA/strsm.c
@@ -48,6 +48,7 @@ void _STRSM(const char *side, const char *uplo, const char *transa, const char *
 
          return;
     }
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
          DEBUG2(fprintf(stderr,"gpu: strsm args: side=%c, uplo=%c, transa=%c, diag=%c, m=%d, n=%d, alpha=%.1e, lda=%d, ldb=%d\n",
            *side, *uplo, *transa, *diag, *m, *n, *alpha, *alpha, *lda, *ldb));
 
@@ -60,22 +61,23 @@ void _STRSM(const char *side, const char *uplo, const char *transa, const char *
 if(scilib_offload_mode == 1){
     float *d_A, *d_B;
 
-    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasStrsm(scilib_cublas_handle, gpu_side, gpu_uplo, gpu_transa, gpu_diag, *m, *n, alpha, d_A, *lda, d_B, *ldb));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG1(t1 += scilib_second());
     CUDA_CHECK(cudaMemcpy(B, d_B, sizeB, cudaMemcpyDeviceToHost));
 
-    CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_B, scilib_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_B, current_cuda_stream));
 
 }
 else {
@@ -90,8 +92,9 @@ else {
     }
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasStrsm(scilib_cublas_handle, gpu_side, gpu_uplo, gpu_transa, gpu_diag, *m, *n, alpha, A, *lda, B, *ldb));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG3(fprintf(stderr,"c,NUMA location of A,B: %d %d\n", inumaA, inumaB));
     DEBUG1(t1 += scilib_second());
 }

--- a/blas/NVIDIA/zhemm.c
+++ b/blas/NVIDIA/zhemm.c
@@ -52,6 +52,7 @@ void _ZHEMM(const char *side, const char *uplo, const int *m, const int *n, cons
 
          return;
     }
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
          DEBUG2(fprintf(stderr,"gpu: zhemm args: side=%c, uplo=%c, m=%d, n=%d, alpha=(%.1e, %.1e), lda=%d, ldb=%d, beta=(%.1e, %.1e), ldc=%d\n",
            *side, *uplo, *m, *n, creal(*(double complex*)alpha), cimag(*(double complex*)alpha),
            *lda, *ldb,creal(*(double complex*)beta),cimag(*(double complex*)beta) , *ldc));
@@ -62,26 +63,27 @@ void _ZHEMM(const char *side, const char *uplo, const int *m, const int *n, cons
 if(scilib_offload_mode == 1){
     cuDoubleComplex *d_A, *d_B, *d_C;
 
-    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, scilib_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, current_cuda_stream));
 //    if( beta_abs > 1.0e-8 )  bug if gemm on a submatrix
-    CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasZhemm(scilib_cublas_handle, gpu_side, gpu_uplo, *m, *n, alpha, A, *lda, B, *ldb, beta, C, *ldc));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG1(t1 += scilib_second());
     CUDA_CHECK(cudaMemcpy(C, d_C, sizeC, cudaMemcpyDeviceToHost));
 
-    CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_B, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_C, scilib_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_B, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_C, current_cuda_stream));
 
 }
 else {
@@ -98,8 +100,9 @@ else {
     }
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasZhemm(scilib_cublas_handle, gpu_side, gpu_uplo, *m, *n, alpha, A, *lda, B, *ldb, beta, C, *ldc));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG3(fprintf(stderr,"c,NUMA location of A,B,C: %d %d %d\n", inumaA, inumaB, inumaC));
     DEBUG1(t1 += scilib_second());
 }

--- a/blas/NVIDIA/zherk.c
+++ b/blas/NVIDIA/zherk.c
@@ -49,6 +49,7 @@ void _ZHERK(const char *uplo, const char *trans, const int *n, const int *k, con
         return;
     }
 
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
     DEBUG2(fprintf(stderr,"gpu: zherk args: uplo=%c, trans=%c, n=%d, k=%d, alpha=(%.1e, %.1e), \
       lda=%d, beta=(%.1e, %.1e), ldc=%d\n",
       *uplo, *trans, *n, *k, creal(*(double complex*)alpha), cimag(*(double complex*)alpha),
@@ -60,22 +61,23 @@ void _ZHERK(const char *uplo, const char *trans, const int *n, const int *k, con
     if(scilib_offload_mode == 1) {
         cuDoubleComplex *d_A, *d_C;
 
-        CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-        CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, scilib_cuda_stream));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+        CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, current_cuda_stream));
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-        CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
         DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
         CUBLAS_CHECK(cublasZherk(scilib_cublas_handle, gpu_uplo, gpu_trans, *n, *k, alpha, d_A, *lda, beta, d_C, *ldc));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
         DEBUG1(t1 += scilib_second());
         CUDA_CHECK(cudaMemcpy(C, d_C, sizeC, cudaMemcpyDeviceToHost));
 
-        CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-        CUDA_CHECK(cudaFreeAsync(d_C, scilib_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_C, current_cuda_stream));
     }
     else {
         int inumaA, inumaC;
@@ -89,8 +91,9 @@ void _ZHERK(const char *uplo, const char *trans, const int *n, const int *k, con
         }
 
         DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
         CUBLAS_CHECK(cublasZherk(scilib_cublas_handle, gpu_uplo, gpu_trans, *n, *k, alpha, A, *lda, beta, C, *ldc));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
         DEBUG3(fprintf(stderr,"c,NUMA location of A,C: %d %d\n", inumaA, inumaC));
         DEBUG1(t1 += scilib_second());
     }

--- a/blas/NVIDIA/zsymm.c
+++ b/blas/NVIDIA/zsymm.c
@@ -52,6 +52,7 @@ void _ZSYMM(const char *side, const char *uplo, const int *m, const int *n, cons
 
          return;
     }
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
          DEBUG2(fprintf(stderr,"gpu: zsymm args: side=%c, uplo=%c, m=%d, n=%d, alpha=(%.1e, %.1e), lda=%d, ldb=%d, beta=(%.1e, %.1e), ldc=%d\n",
            *side, *uplo, *m, *n, crealf(*(double complex*)alpha), cimagf(*(double complex*)alpha),
            *lda, *ldb,crealf(*(double complex*)beta),cimagf(*(double complex*)beta) , *ldc));
@@ -62,26 +63,27 @@ void _ZSYMM(const char *side, const char *uplo, const int *m, const int *n, cons
 if(scilib_offload_mode == 1){
     cuDoubleComplex *d_A, *d_B, *d_C;
 
-    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, scilib_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, current_cuda_stream));
 //    if( beta_abs > 1.0e-8 )  bug if gemm on a submatrix
-    CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasZsymm(scilib_cublas_handle, gpu_side, gpu_uplo, *m, *n, alpha, A, *lda, B, *ldb, beta, C, *ldc));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG1(t1 += scilib_second());
     CUDA_CHECK(cudaMemcpy(C, d_C, sizeC, cudaMemcpyDeviceToHost));
 
-    CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_B, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_C, scilib_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_B, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_C, current_cuda_stream));
 
 }
 else {
@@ -98,8 +100,9 @@ else {
     }
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasZsymm(scilib_cublas_handle, gpu_side, gpu_uplo, *m, *n, alpha, A, *lda, B, *ldb, beta, C, *ldc));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG3(fprintf(stderr,"c,NUMA location of A,B,C: %d %d %d\n", inumaA, inumaB, inumaC));
     DEBUG1(t1 += scilib_second());
 }

--- a/blas/NVIDIA/zsyr2k.c
+++ b/blas/NVIDIA/zsyr2k.c
@@ -50,6 +50,7 @@ void _ZSYR2K(const char *uplo, const char *trans, const int *n, const int *k, co
         return;
     }
 
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
     DEBUG2(fprintf(stderr,"gpu: zsyr2k args: uplo=%c, trans=%c, n=%d, k=%d, alpha=(%.1e, %.1e), lda=%d, ldb=%d, beta=(%.1e, %.1e), ldc=%d\n",
       *uplo, *trans, *n, *k, creal(*(double complex*)alpha), cimag(*(double complex*)alpha),
       *lda, *ldb, creal(*(double complex*)beta), cimag(*(double complex*)beta), *ldc));
@@ -68,25 +69,26 @@ void _ZSYR2K(const char *uplo, const char *trans, const int *n, const int *k, co
     if(scilib_offload_mode == 1) {
         cuDoubleComplex *d_A, *d_B, *d_C;
 
-        CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-        CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, scilib_cuda_stream));
-        CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, scilib_cuda_stream));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+        CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, current_cuda_stream));
+        CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, current_cuda_stream));
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-        CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
         DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
         CUBLAS_CHECK(cublasZsyr2k(scilib_cublas_handle, gpu_uplo, gpu_trans, *n, *k, alpha, d_A, *lda, d_B, *ldb, beta, d_C, *ldc));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
         DEBUG1(t1 += scilib_second());
         CUDA_CHECK(cudaMemcpy(C, d_C, sizeC, cudaMemcpyDeviceToHost));
 
-        CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-        CUDA_CHECK(cudaFreeAsync(d_B, scilib_cuda_stream));
-        CUDA_CHECK(cudaFreeAsync(d_C, scilib_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_B, current_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_C, current_cuda_stream));
     }
     else {
         int inumaA, inumaB, inumaC;
@@ -102,8 +104,9 @@ void _ZSYR2K(const char *uplo, const char *trans, const int *n, const int *k, co
         }
 
         DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
         CUBLAS_CHECK(cublasZsyr2k(scilib_cublas_handle, gpu_uplo, gpu_trans, *n, *k, alpha, A, *lda, B, *ldb, beta, C, *ldc));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
         DEBUG3(fprintf(stderr,"c,NUMA location of A,B,C: %d %d %d\n", inumaA, inumaB, inumaC));
         DEBUG1(t1 += scilib_second());
     }

--- a/blas/NVIDIA/zsyrk.c
+++ b/blas/NVIDIA/zsyrk.c
@@ -49,6 +49,7 @@ void _ZSYRK(const char *uplo, const char *trans, const int *n, const int *k, con
         return;
     }
 
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
     DEBUG2(fprintf(stderr,"gpu: zsyrk args: uplo=%c, trans=%c, n=%d, k=%d, alpha=(%.1e, %.1e), \
       lda=%d, beta=(%.1e, %.1e), ldc=%d\n",
       *uplo, *trans, *n, *k, creal(*(double complex*)alpha), cimag(*(double complex*)alpha),
@@ -68,22 +69,23 @@ void _ZSYRK(const char *uplo, const char *trans, const int *n, const int *k, con
     if(scilib_offload_mode == 1) {
         cuDoubleComplex *d_A, *d_C;
 
-        CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-        CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, scilib_cuda_stream));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+        CUDA_CHECK(cudaMallocAsync((void **)&d_C, sizeC, current_cuda_stream));
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-        CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, scilib_cuda_stream));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaMemcpyAsync(d_C, C, sizeC, cudaMemcpyHostToDevice, current_cuda_stream));
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
         DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
         CUBLAS_CHECK(cublasZsyrk(scilib_cublas_handle, gpu_uplo, gpu_trans, *n, *k, alpha, d_A, *lda, beta, d_C, *ldc));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
         DEBUG1(t1 += scilib_second());
         CUDA_CHECK(cudaMemcpy(C, d_C, sizeC, cudaMemcpyDeviceToHost));
 
-        CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-        CUDA_CHECK(cudaFreeAsync(d_C, scilib_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+        CUDA_CHECK(cudaFreeAsync(d_C, current_cuda_stream));
     }
     else {
         int inumaA, inumaC;
@@ -97,8 +99,9 @@ void _ZSYRK(const char *uplo, const char *trans, const int *n, const int *k, con
         }
 
         DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
         CUBLAS_CHECK(cublasZsyrk(scilib_cublas_handle, gpu_uplo, gpu_trans, *n, *k, alpha, A, *lda, beta, C, *ldc));
-        CUDA_CHECK(cudaDeviceSynchronize());
+        CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
         DEBUG3(fprintf(stderr,"c,NUMA location of A,C: %d %d\n", inumaA, inumaC));
         DEBUG1(t1 += scilib_second());
     }

--- a/blas/NVIDIA/ztrmm.c
+++ b/blas/NVIDIA/ztrmm.c
@@ -48,6 +48,7 @@ void _ZTRMM(const char *side, const char *uplo, const char *transa, const char *
 
          return;
     }
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
     DEBUG2(fprintf(stderr,"gpu: ztrmm args: side=%c, uplo=%c, transa=%c, diag=%c, m=%d, n=%d, alpha=(%.1e, %.1e), lda=%d, ldb=%d\n",
         *side, *uplo, *transa, *diag, *m, *n, creal(*(double complex*)alpha), cimag(*(double complex*)alpha), *lda, *ldb));
 
@@ -60,22 +61,23 @@ void _ZTRMM(const char *side, const char *uplo, const char *transa, const char *
 if(scilib_offload_mode == 1){
     cuDoubleComplex *d_A, *d_B;
 
-    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasZtrmm(scilib_cublas_handle, gpu_side, gpu_uplo, gpu_transa, gpu_diag, *m, *n, alpha, d_A, *lda, d_B, *ldb, d_B, *ldb));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG1(t1 += scilib_second());
     CUDA_CHECK(cudaMemcpy(B, d_B, sizeB, cudaMemcpyDeviceToHost));
 
-    CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_B, scilib_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_B, current_cuda_stream));
 
 }
 else {
@@ -90,8 +92,9 @@ else {
     }
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasZtrmm(scilib_cublas_handle, gpu_side, gpu_uplo, gpu_transa, gpu_diag, *m, *n, alpha, A, *lda, B, *ldb, B, *ldb));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG3(fprintf(stderr,"c,NUMA location of A,B: %d %d\n", inumaA, inumaB));
     DEBUG1(t1 += scilib_second());
 }

--- a/blas/NVIDIA/ztrsm.c
+++ b/blas/NVIDIA/ztrsm.c
@@ -48,6 +48,7 @@ void _ZTRSM(const char *side, const char *uplo, const char *transa, const char *
 
          return;
     }
+    cudaStream_t current_cuda_stream = scilib_get_current_thread_stream();
     DEBUG2(fprintf(stderr,"gpu: ztrsm args: side=%c, uplo=%c, transa=%c, diag=%c, m=%d, n=%d, alpha=(%.1e, %.1e), lda=%d, ldb=%d\n",
         *side, *uplo, *transa, *diag, *m, *n, creal(*(double complex*)alpha), cimag(*(double complex*)alpha), *lda, *ldb));
 
@@ -60,22 +61,23 @@ void _ZTRSM(const char *side, const char *uplo, const char *transa, const char *
 if(scilib_offload_mode == 1){
     cuDoubleComplex *d_A, *d_B;
 
-    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, scilib_cuda_stream));
-    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMallocAsync((void **)&d_A, sizeA, current_cuda_stream));
+    CUDA_CHECK(cudaMallocAsync((void **)&d_B, sizeB, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
-    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, scilib_cuda_stream));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaMemcpyAsync(d_A, A, sizeA, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaMemcpyAsync(d_B, B, sizeB, cudaMemcpyHostToDevice, current_cuda_stream));
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasZtrsm(scilib_cublas_handle, gpu_side, gpu_uplo, gpu_transa, gpu_diag, *m, *n, alpha, d_A, *lda, d_B, *ldb));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG1(t1 += scilib_second());
     CUDA_CHECK(cudaMemcpy(B, d_B, sizeB, cudaMemcpyDeviceToHost));
 
-    CUDA_CHECK(cudaFreeAsync(d_A, scilib_cuda_stream));
-    CUDA_CHECK(cudaFreeAsync(d_B, scilib_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_A, current_cuda_stream));
+    CUDA_CHECK(cudaFreeAsync(d_B, current_cuda_stream));
 
 }
 else {
@@ -90,8 +92,9 @@ else {
     }
 
     DEBUG1(t1 -= scilib_second());
+    CUBLAS_CHECK(cublasSetStream(scilib_cublas_handle, current_cuda_stream));
     CUBLAS_CHECK(cublasZtrsm(scilib_cublas_handle, gpu_side, gpu_uplo, gpu_transa, gpu_diag, *m, *n, alpha, A, *lda, B, *ldb));
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaStreamSynchronize(current_cuda_stream));
     DEBUG3(fprintf(stderr,"c,NUMA location of A,B: %d %d\n", inumaA, inumaB));
     DEBUG1(t1 += scilib_second());
 }

--- a/global.h
+++ b/global.h
@@ -6,6 +6,7 @@ extern int scilib_debug;                  //SCILIB_DEBUG
 extern int scilib_thpoff;                 //SCILIB_THPOFF
 extern int scilib_offload_mode;           //SCILIB_OFFLOAD_MODE
 extern char **scilib_offload_func;        //SCILIB_OFFLOAD_FUNC
+extern int scilib_num_cuda_streams;       //SCILIB_NUM_STREAMS
 
 
 extern int scilib_skip_flag;

--- a/init.c
+++ b/init.c
@@ -13,6 +13,7 @@ int scilib_debug;                      //SCILIB_DEBUG
 int scilib_thpoff;                     //SCILIB_THPOFF
 int scilib_offload_mode;               //SCILIB_OFFLOAD_MODE
 char **scilib_offload_func;            //SCILIB_OFFLOAD_FUNC, only these comma separated funcs are intercepted in DBI.
+int scilib_num_cuda_streams;           //SCILIB_NUM_STREAMS
 
 
 void scilib_parse_env_var() {
@@ -34,6 +35,9 @@ void scilib_parse_env_var() {
 
     env_str = getenv("SCILIB_OFFLOAD_FUNC");
     scilib_offload_func = env_str ? str_split(env_str,',') : NULL; 
+
+    env_str = getenv("SCILIB_NUM_STREAMS") ;
+    scilib_num_cuda_streams = env_str? atoi(env_str) : 1;
      
 }
 

--- a/main-dl.c
+++ b/main-dl.c
@@ -16,6 +16,7 @@
 
 //to disable THP
 #include <sys/prctl.h> 
+#include "scilib_pthread_wrap.h"
 
 
 scilib_freplace scilib_farray[] = {
@@ -25,6 +26,13 @@ int scilib_fsize = sizeof(scilib_farray) / sizeof(scilib_farray[0]);
 
 char *exe_path;
 int scilib_skip_flag; 
+
+int pthread_create(pthread_t *__restrict thread,
+  const pthread_attr_t *__restrict attr,
+  void *(*start_routine)(void *),
+  void *__restrict arg) {
+    scilib_pthread_create_wrapper(thread, attr, start_routine, arg);
+  }
 
 void scilib_elf_init(){
 
@@ -40,6 +48,8 @@ void scilib_elf_init(){
 #ifdef NVIDIA
   scilib_nvidia_init();
 #endif
+
+  scilib_pthread_wrap_init();
 
 // register functions
   for( int i=0; i< scilib_fsize; i++) {

--- a/nvidia.h
+++ b/nvidia.h
@@ -6,7 +6,8 @@
 
 extern cublasHandle_t scilib_cublas_handle;
 extern cusolverDnHandle_t scilib_cusolverdn_handle;
-extern cudaStream_t scilib_cuda_stream;
+extern cudaStream_t *scilib_cuda_streams; 
+extern int scilib_num_cuda_streams;      
 
 void scilib_nvidia_init();
 void scilib_nvidia_fini();

--- a/scilib_pthread_wrap.c
+++ b/scilib_pthread_wrap.c
@@ -1,0 +1,97 @@
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "scilib_pthread_wrap.h"
+#include "nvidia.h" // For scilib_cuda_streams, scilib_num_cuda_streams
+#include "global.h" // For any debug macros if needed
+
+int (*real_pthread_create)(pthread_t *__restrict,
+                           const pthread_attr_t *__restrict,
+                           void *(*__start_routine)(void *),
+                           void *__restrict) = NULL;
+
+// Thread-Local Storage for the stream
+__thread cudaStream_t current_thread_stream_tls = (cudaStream_t)-2; // Uninitialized state
+
+static pthread_mutex_t stream_assignment_lock = PTHREAD_MUTEX_INITIALIZER;
+static int next_stream_index = 0;
+
+// Internal function to assign a stream
+static void assign_stream_to_current_thread() {
+    pthread_mutex_lock(&stream_assignment_lock);
+    if (scilib_num_cuda_streams > 0 && scilib_cuda_streams != NULL) {
+        current_thread_stream_tls = scilib_cuda_streams[next_stream_index];
+        next_stream_index = (next_stream_index + 1) % scilib_num_cuda_streams;
+    } else {
+        // Fallback to default stream (0) if streams aren't initialized
+        // or if scilib_num_cuda_streams is 0.
+        current_thread_stream_tls = (cudaStream_t)0;
+    }
+    pthread_mutex_unlock(&stream_assignment_lock);
+}
+
+cudaStream_t scilib_get_current_thread_stream(void) {
+    if (current_thread_stream_tls == (cudaStream_t)-2) { // Check for uninitialized state
+        assign_stream_to_current_thread();
+    }
+    return current_thread_stream_tls;
+}
+
+typedef struct {
+    void *(*user_start_routine)(void *);
+    void *user_arg;
+} thread_starter_args_t;
+
+static void *thread_starter_wrapper(void *arg) {
+    thread_starter_args_t *wrapper_args = (thread_starter_args_t *)arg;
+    void *(*actual_start_routine)(void *) = wrapper_args->user_start_routine;
+    void *actual_arg = wrapper_args->user_arg;
+
+    free(wrapper_args); // Clean up the temporary args structure
+
+    // Assign a stream to this new thread when it starts
+    assign_stream_to_current_thread();
+
+    return actual_start_routine(actual_arg);
+}
+
+// For LD_PRELOAD, rename this function to "pthread_create"
+// For Frida, keep this name and hook "pthread_create" to point to this.
+int scilib_pthread_create_wrapper(pthread_t *__restrict thread,
+                                  const pthread_attr_t *__restrict attr,
+                                  void *(*start_routine)(void *),
+                                  void *__restrict arg) {
+    if (!real_pthread_create) {
+        // This dlsym is essential for LD_PRELOAD.
+        // For Frida, real_pthread_create is populated by the gum_interceptor_replace_fast call.
+        real_pthread_create = dlsym(RTLD_NEXT, "pthread_create");
+        if (!real_pthread_create) {
+            fprintf(stderr, "SCILIB: Critical error: dlsym failed to find real pthread_create.\n");
+            // This is a fatal error for LD_PRELOAD if it happens.
+            // For Frida, if gum_interceptor_replace_fast failed, this might also be null.
+            return -1; // Indicate error
+        }
+    }
+
+    thread_starter_args_t *wrapper_args = (thread_starter_args_t *)malloc(sizeof(thread_starter_args_t));
+    if (!wrapper_args) {
+        fprintf(stderr, "SCILIB: Failed to allocate memory for thread wrapper args. Calling original pthread_create.\n");
+        return real_pthread_create(thread, attr, start_routine, arg);
+    }
+    wrapper_args->user_start_routine = start_routine;
+    wrapper_args->user_arg = arg;
+
+    return real_pthread_create(thread, attr, thread_starter_wrapper, wrapper_args);
+}
+
+void scilib_pthread_wrap_init(void) {
+    // For the main thread, assign a stream now.
+    // Ensure scilib_nvidia_init (which creates streams) has been called before this.
+    assign_stream_to_current_thread();
+
+    // If not using LD_PRELOAD for pthread_create (i.e., using Frida),
+    // real_pthread_create will be set by Frida.
+    // If using LD_PRELOAD, real_pthread_create will be set on the first call
+    // to the wrapper if not already set.
+}

--- a/scilib_pthread_wrap.h
+++ b/scilib_pthread_wrap.h
@@ -1,0 +1,28 @@
+#ifndef SCILIB_PTHREAD_WRAP_H
+#define SCILIB_PTHREAD_WRAP_H
+
+#include <pthread.h>
+#include <cuda_runtime.h>
+
+// Function pointer for the original pthread_create
+extern int (*real_pthread_create)(pthread_t *__restrict,
+                                   const pthread_attr_t *__restrict,
+                                   void *(*__start_routine)(void *),
+                                   void *__restrict);
+
+// Our wrapper/interceptor for pthread_create
+// For LD_PRELOAD, this function will be named "pthread_create"
+// For Frida, this will be the replacement function
+int scilib_pthread_create_wrapper(pthread_t *__restrict thread,
+                                  const pthread_attr_t *__restrict attr,
+                                  void *(*start_routine)(void *),
+                                  void *__restrict arg);
+
+// Gets the CUDA stream assigned to the current thread
+cudaStream_t scilib_get_current_thread_stream(void);
+
+// To be called from scilib_elf_init to setup interception (especially for Frida)
+// and to assign a stream to the main thread.
+void scilib_pthread_wrap_init(void);
+
+#endif // SCILIB_PTHREAD_WRAP_H

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -72,15 +72,15 @@ int which_numa(void *ptr, size_t bytes) {
 }
 
 #include "nvidia.h"
-void move_numa2(void *ptr, size_t size, int target_node) {
-    double alpha = 1.0;
-    size_t num_elements = size / sizeof(double);
-    for (int i = 0; i < 1; i++) {
-        CUBLAS_CHECK(cublasDscal(scilib_cublas_handle, num_elements, &alpha, (double*)ptr, 1));
-        cudaStreamSynchronize(scilib_cuda_stream);
-    }
-    return;
-}
+// void move_numa2(void *ptr, size_t size, int target_node) {
+//     double alpha = 1.0;
+//     size_t num_elements = size / sizeof(double);
+//     for (int i = 0; i < 1; i++) {
+//         CUBLAS_CHECK(cublasDscal(scilib_cublas_handle, num_elements, &alpha, (double*)ptr, 1));
+//         cudaStreamSynchronize(scilib_cuda_stream);
+//     }
+//     return;
+// }
 
 void move_numa(void *ptr, size_t size, int target_node) {
 // size in Bytes


### PR DESCRIPTION
Add new env var `SCILIB_NUM_STREAMS`. When there are multiple threads, each thread will be assigned a stream in a round-robin fashion. The streams can run in parallel if possible, 